### PR TITLE
[README] Update channel pricing namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ setono_sylius_catalog_promotion_admin:
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Entity\Channel;
 
 use Doctrine\ORM\Mapping as ORM;
 use Setono\SyliusCatalogPromotionPlugin\Model\ChannelPricingInterface as CatalogPromotionChannelPricingInterface;


### PR DESCRIPTION
By default in Sylius-Standard, this class is placed in Entity/Channel/ChannelPricing.php, so if one would install current Sylius-Standard they can expect slightly different namespace.