### PR TITLE
Adjust bundle notation while referencing templates

### DIFF
--- a/src/Resources/views/Admin/_javascripts.html.twig
+++ b/src/Resources/views/Admin/_javascripts.html.twig
@@ -1,1 +1,1 @@
-{% include 'SyliusUiBundle::_javascripts.html.twig' with {'path': 'bundles/setonosyliuscatalogpromotionplugin/js/app.js'} %}
+{% include '@SyliusUi/_javascripts.html.twig' with {'path': 'bundles/setonosyliuscatalogpromotionplugin/js/app.js'} %}


### PR DESCRIPTION
Hi!
As reported [here](https://github.com/Sylius/SyliusThemeBundle/blob/master/UPGRADE.md#referencing-templates) the new SyliusThemeBundle has removed support for bundle notation while referencing templates. This PR will fix the problem.