### PR TITLE
Adjust bundle notation on templates

### DIFF
--- a/src/Resources/config/admin_routing.yaml
+++ b/src/Resources/config/admin_routing.yaml
@@ -3,7 +3,7 @@ setono_sylius_catalog_promotion_admin_promotion:
         alias: setono_sylius_catalog_promotion.promotion
         path: catalog-promotions
         section: admin
-        templates: '@SyliusAdmin/Crud'
+        templates: '@SyliusAdmin\\Crud'
         except: ['show']
         redirect: update
         grid: setono_sylius_catalog_promotion_admin_promotion


### PR DESCRIPTION
As shown [here](https://docs.sylius.com/en/1.8/cookbook/entities/custom-model.html#define-routing-for-entity-administration) Sylius use the double backslash to refer to the template in the controller. This also solves a problem using Symfony 5.2.