### PR TITLE
Fix 'compound discount' bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "doctrine/event-manager": "^1.1",
         "doctrine/orm": "^2.7",
         "knplabs/knp-menu": "^3.2",
-        "setono/job-status-bundle": "^0.2.1",
+        "setono/job-status-bundle": "^0.2.3",
         "sylius/registry": "^1.6",
         "sylius/resource-bundle": "^1.6",
         "symfony/config": "^4.4 || ^5.0",

--- a/src/Doctrine/ORM/ChannelPricingRepositoryTrait.php
+++ b/src/Doctrine/ORM/ChannelPricingRepositoryTrait.php
@@ -102,10 +102,15 @@ trait ChannelPricingRepositoryTrait
                 'channelPricing.bulkIdentifier is null',
                 'channelPricing.bulkIdentifier = :bulkIdentifier',
             ))
-            // here are two more safety checks. If the promotion code is already applied,
+            // here is another safety check. If the promotion code is already applied,
             // do not select this pricing for a discount
-            ->andWhere('channelPricing.appliedPromotions NOT LIKE :promotionEnding')
-            ->andWhere('channelPricing.appliedPromotions NOT LIKE :promotionMiddle')
+            ->andWhere($qb->expr()->orX(
+                'channelPricing.appliedPromotions IS NULL',
+                $qb->expr()->andX(
+                    'channelPricing.appliedPromotions NOT LIKE :promotionEnding',
+                    'channelPricing.appliedPromotions NOT LIKE :promotionMiddle',
+                )
+            ))
             ->set('channelPricing.updatedAt', ':date')
             ->set('channelPricing.bulkIdentifier', ':bulkIdentifier')
             ->set('channelPricing.appliedPromotions', "CONCAT(COALESCE(channelPricing.appliedPromotions, ''), CONCAT(',', :promotion))")


### PR DESCRIPTION
This PR tries to fix an very edge case bug where a discount could be applied multiple times on the same `channelPricing`